### PR TITLE
add -v argument to g42-run.sh

### DIFF
--- a/iss-cw4/dbserver/persistent-data/readme.md
+++ b/iss-cw4/dbserver/persistent-data/readme.md
@@ -1,0 +1,1 @@
+This file only exists to allow the creation of the directory.

--- a/iss-cw4/g42-scripts/g42-run.sh
+++ b/iss-cw4/g42-scripts/g42-run.sh
@@ -2,6 +2,6 @@
 # Run this script to load the script
 
 # Runs the docker database image
-docker run -d --net iss2022/g42_n --ip 192.0.2.201 --hostname db.cyber2022.test -e MYSQL_ROOT_PASSWORD="CorrectHorseBatteryStaple" -e MYSQL_DATABASE="iss2022db" --security-opt label:type:docker-g42-db_t --name iss2022_g42-db_c iss2022/g42-db_i
+docker run -d --net iss2022/g42_n --ip 192.0.2.201 --hostname db.cyber2022.test -e MYSQL_ROOT_PASSWORD="CorrectHorseBatteryStaple" -e MYSQL_DATABASE="iss2022db" --security-opt label:type:docker-g42-db_t -v /home/csc/iss-cw4/iss-cw4/dbserver/persistent-data:/var/lib/mysql --name iss2022_g42-db_c iss2022/g42-db_i
 # Runs the docker 
 docker run -d --net iss2022/g42_n --ip 192.0.2.202 --hostname www.cyber2022.test --add-host db.cyber2022.test:192.0.2.201 -p 80:80 --security-opt label:type:docker-g42-web_t --name iss2022_g42-web_c iss2022/g42-web_i


### PR DESCRIPTION
This adds the argument for the database docker run command to use the persistent-data directory in dbserver as the place to store mysql datafiles.